### PR TITLE
Update Cognito post-confirmation Lambda hook

### DIFF
--- a/backend/src/handlers/post_confirmation/app.py
+++ b/backend/src/handlers/post_confirmation/app.py
@@ -33,7 +33,7 @@ def lambda_handler(event: Dict[str, Any], context: LambdaContext) -> Dict[str, A
         PostConfirmationTriggerEvent(event)
     )
     user_attributes = post_confirmation_trigger_event.request.user_attributes
-    email = user_attributes["cognito:email_alias"]
+    email = user_attributes["email"]
     logger.info(f"email: {email}")
 
     # create SNS subscription


### PR DESCRIPTION
I was running though this workshop in preparation for an upcoming event - when signing up on the frontend, I was getting an error after inputting my confirmation code:

![image](https://github.com/aws-samples/serverless-registration-app-genai/assets/38150523/4b170c84-60db-4759-9947-3fe46d85bfcc)

I traced it back to the post confirmation Lambda trigger - it was trying to reference `cognito:email_alias` instead of simply `email` which stores the user email. This error was also preventing the SNS subscription from being auto-created since this is also done in the same Lambda function.

I changed the line of code, redeployed, and all is working well.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
